### PR TITLE
Fix Unary Clauses

### DIFF
--- a/model.go
+++ b/model.go
@@ -184,7 +184,6 @@ func (s *variableSet[T]) String() string {
 	return strings.Join(t, ", ")
 }
 
-//nolint:unused
 func (s *variableSet[T]) dump() {
 	fmt.Println("Variables:")
 	fmt.Println(s)
@@ -507,7 +506,6 @@ func (l *clauseList) destroy() {
 	}
 }
 
-//nolint:unused
 func (l *clauseList) dump() {
 	fmt.Println("clauses:")
 
@@ -591,13 +589,17 @@ func (m *Model[T]) Clause(literals ...*Literal) {
 }
 
 // Unary adds a unary clause e.g. this must be true.
-func (m *Model[T]) Unary(t T) error {
-	return m.variables.get(t).define(true)
+// NOTE: The assumption here is this is an initial condition for the problem
+// being solved, and should not be preserved across resets.
+func (m *Model[T]) Unary(t T) {
+	m.learnedClauses.create([]*Literal{m.Literal(t)})
 }
 
 // NegatedUnary adds a negated unary clause e.g. this must be false.
-func (m *Model[T]) NegatedUnary(t T) error {
-	return m.variables.get(t).define(false)
+// NOTE: The assumption here is this is an initial condition for the problem
+// being solved, and should not be preserved across resets.
+func (m *Model[T]) NegatedUnary(t T) {
+	m.learnedClauses.create([]*Literal{m.NegatedLiteral(t)})
 }
 
 // AtLeastOneOf is a helper that defines a clause:
@@ -685,8 +687,7 @@ func (m *Model[T]) Reset() {
 	m.learnedClauses = newClauseList()
 }
 
-//nolint:unused
-func (m *Model[T]) dump() {
+func (m *Model[T]) Dump() {
 	m.variables.dump()
 	m.clauses.dump()
 }

--- a/solver_test.go
+++ b/solver_test.go
@@ -105,9 +105,7 @@ func sudokuInitialize(m *sat.Model[variable]) {
 	for i := range 9 {
 		for j := range 9 {
 			if sudoku[i][j] > 0 {
-				if err := m.Unary(variable{i, j, sudoku[i][j] - 1}); err != nil {
-					panic("unary value caused a conflict!")
-				}
+				m.Unary(variable{i, j, sudoku[i][j] - 1})
 			}
 		}
 	}


### PR DESCRIPTION
Before this it was possible to set v0 to true, and have a clause ~v0. The way it workd was it would see the clause as unary, because no notification happened, and it would set it to false and be satisfiable erroneously.  As unary clauses are considered initial-state, we should add them to the learned clauses so they are not persisted across model reuse.